### PR TITLE
Add STATIC_ROOT setting

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -140,6 +140,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- specify `STATIC_ROOT` directory in Django settings to configure static file collection

## Testing
- `python -m pip install -r backend/requirements.txt`
- `python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6867c19d1438832db54e11f006dc0de2